### PR TITLE
Update  bigquery adapter based on upstream & review notes

### DIFF
--- a/autoload/db_ui/schemas.vim
+++ b/autoload/db_ui/schemas.vim
@@ -141,11 +141,22 @@ let s:oracle = {
       \   'filetype': 'plsql',
       \ }
 
+if !exists('g:db_adapter_bigquery_region')
+  let g:db_adapter_bigquery_region = 'region-us'
+endif
+
+let s:bigquery_schemas_query = "SELECT schema_name FROM INFORMATION_SCHEMA.SCHEMATA" 
+
+let s:bigquery_schema_tables_query = printf("
+      \ SELECT table_schema, table_name
+      \ FROM `%s`.INFORMATION_SCHEMA.TABLES
+      \ ", g:db_adapter_bigquery_region)
+
 let s:bigquery = {
       \ 'callable': 'filter',
       \ 'args': ['--format=csv'],
-      \ 'schemes_query': "SELECT schema_name FROM INFORMATION_SCHEMA.SCHEMATA",
-      \ 'schemes_tables_query': "SELECT table_schema, table_name FROM `region-us`.INFORMATION_SCHEMA.TABLES",
+      \ 'schemes_query': s:bigquery_schemas_query
+      \ 'schemes_tables_query': s:bigquery_schema_tables_query,
       \ 'parse_results': {results, min_len -> s:results_parser(results[1:], ',', min_len)},
       \ 'layout_flag': '\\x',
       \ 'requires_stdin': v:true,

--- a/autoload/db_ui/schemas.vim
+++ b/autoload/db_ui/schemas.vim
@@ -142,12 +142,13 @@ let s:oracle = {
       \ }
 
 let s:bigquery = {
+      \ 'callable': 'filter',
       \ 'args': ['--format=csv'],
       \ 'schemes_query': "SELECT schema_name FROM INFORMATION_SCHEMA.SCHEMATA",
       \ 'schemes_tables_query': "SELECT table_schema, table_name FROM `region-us`.INFORMATION_SCHEMA.TABLES",
       \ 'parse_results': {results, min_len -> s:results_parser(results[1:], ',', min_len)},
       \ 'layout_flag': '\\x',
-      \ 'requires_stdin': v:false,
+      \ 'requires_stdin': v:true,
       \ }
 
 
@@ -174,7 +175,8 @@ endfunction
 
 function! s:format_query(db, scheme, query) abort
   let conn = type(a:db) == v:t_string ? a:db : a:db.conn
-  let cmd = db#adapter#dispatch(conn, 'interactive') + get(a:scheme, 'args', [])
+  let callable = get(a:scheme, 'callable', 'interactive')
+  let cmd = db#adapter#dispatch(conn, callable) + get(a:scheme, 'args', [])
   if get(a:scheme, 'requires_stdin')
     return [cmd, a:query]
   endif


### PR DESCRIPTION
## Summary

- This PR updates the branch with the changes pulled in from https://github.com/tpope/vim-dadbod/pull/125
- It also adds a global variable `g:db_adapter_bigquery_region` that may be set to control the region in the schema query